### PR TITLE
fix: fixing bug in update-docs script

### DIFF
--- a/create-pr/action.yml
+++ b/create-pr/action.yml
@@ -53,17 +53,19 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        FILES_TO_ADD: ${{ inputs.files }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
       run: |
         BRANCH_NAME="${{ inputs.branch-prefix }}-$(date +%Y%m%d)-${{ github.run_id }}"
 
         echo "::debug::Creating branch: $BRANCH_NAME"
         git checkout -b "$BRANCH_NAME"
 
-        echo "::debug::Adding files: ${{ inputs.files }}"
-        git add ${{ inputs.files }}
+        echo "::debug::Adding files: $FILES_TO_ADD"
+        git add $FILES_TO_ADD
 
-        echo "::debug::Committing changes with message: '${{ inputs.commit-message }}'"
-        git commit -m "${{ inputs.commit-message }}"
+        echo "::debug::Committing changes with message: '$COMMIT_MESSAGE'"
+        git commit -m "$COMMIT_MESSAGE"
 
         echo "::debug::Pushing branch $BRANCH_NAME to origin"
         git push --force origin "$BRANCH_NAME"
@@ -75,10 +77,13 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        PR_TITLE: ${{ inputs.pr-title }}
+        PR_BODY: ${{ inputs.pr-body }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
       run: |
-        echo "::debug::Creating pull request from $BRANCH_NAME to ${{ inputs.base-branch }}"
+        echo "::debug::Creating pull request from $BRANCH_NAME to $BASE_BRANCH"
         gh pr create \
-          --title "${{ inputs.pr-title }}" \
-          --body "${{ inputs.pr-body }}" \
+          --title "$PR_TITLE" \
+          --body "$PR_BODY" \
           --head "$BRANCH_NAME" \
-          --base "${{ inputs.base-branch }}"
+          --base "$BASE_BRANCH"

--- a/sync-tags-in-docs/action.yml
+++ b/sync-tags-in-docs/action.yml
@@ -165,7 +165,7 @@ runs:
           echo "::debug::New tag version: $NEW_TAG_VERSION"
           
           # Replace all occurrences of the pattern with the new version
-          sed -i.bak "s|${PATTERN}[^[:space:])]]*|${PATTERN}${NEW_TAG_VERSION}|g" "$file"
+          sed -i.bak "s|${PATTERN}[^[:space:])]]*|${PATTERN%@}@${NEW_TAG_VERSION}|g" "$file"
           
           # Check if file was actually modified
           if ! cmp -s "$file" "$file.bak"; then


### PR DESCRIPTION
Avoid the need for escaping and command line injection into the bash variables when creating a PR.