### PR TITLE
fix(semantic-release): only emit tag output for newly created releases

### DIFF
--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -85,6 +85,14 @@ runs:
       shell: bash
       run: echo "~/.npm-global/bin" >> $GITHUB_PATH
 
+    - name: Capture pre-existing tags at HEAD
+      id: pre-release-tags
+      shell: bash
+      run: |
+        git fetch --tags origin
+        BEFORE=$(git tag --points-at HEAD | sort | paste -sd ',' -)
+        echo "tags=$BEFORE" >> "$GITHUB_OUTPUT"
+
     - name: Run semantic-release
       shell: bash
       env:
@@ -94,9 +102,18 @@ runs:
     - name: Resolve release outputs
       id: release
       shell: bash
+      env:
+        TAGS_BEFORE: ${{ steps.pre-release-tags.outputs.tags }}
       run: |
         git fetch --tags origin
-        TAG=$(git tag --points-at HEAD --sort=-v:refname | head -1)
+        # Only emit a tag when semantic-release actually created a new one at HEAD.
+        # Comparing against the pre-existing tag set prevents picking up tags that
+        # were created by a prior workflow run on a different branch (e.g. a main
+        # release tag that became visible on develop after a backmerge of the same
+        # commit).
+        BEFORE_SORTED=$(printf '%s\n' "$TAGS_BEFORE" | tr ',' '\n' | sort -u)
+        AFTER_SORTED=$(git tag --points-at HEAD | sort -u)
+        TAG=$(comm -13 <(echo "$BEFORE_SORTED") <(echo "$AFTER_SORTED") | sort -V | tail -1)
 
         if [ -n "$TAG" ]; then
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The `Resolve release outputs` step uses:

```bash
TAG=$(git tag --points-at HEAD --sort=-v:refname | head -1)
```

This picks up *any* tag pointing at HEAD, including tags created by a prior workflow run on a different branch. In our main↔develop backmerge flow that causes a real failure:

1. PR merged `develop` → `main` (commit `X`)
2. `main` workflow runs semantic-release → creates `v1.5.0` at `X`, uploads release assets, then backmerges `main` → `develop` (push of identical SHA `X`)
3. The backmerge push triggers the `develop` workflow on commit `X`
4. semantic-release on `develop` has nothing new to release
5. But `git tag --points-at HEAD` returns `v1.5.0` (created by the main run), so `outputs.tag=v1.5.0` is emitted
6. Downstream `gh release upload v1.5.0 …` fails: `asset under the same name already exists`

Observed in:
- https://github.com/alchemaxinc/wintermute-frontend/actions/runs/24824036647
- https://github.com/alchemaxinc/wintermute-backend/actions/runs/24824320395

## Fix

Snapshot the tag set at HEAD *before* running semantic-release, then diff with the post-run set. Only tags that did **not** previously exist are reported as new releases.

## Verified

Manually tested the shell logic:
- New release: emits the new tag ✅
- No-op (backmerge scenario): emits empty ✅
- First-ever release: emits the new tag ✅