### PR TITLE
feat: add detect-changed-files action

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,6 +1,6 @@
 {
   "language": "en",
-  "words": ["alchemaxinc"],
+  "words": ["alchemaxinc", "pathspec", "pathspecs"],
   "files": ["*.md", "*/**/*.md"],
   "ignoreWords": ["releaserc"],
   "ignorePaths": [],

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a helper toolbox for [alchemaxinc/update-deps](https://github.com/alchem
 - **[check-changes](./check-changes/)** - Check if specified files have changes in the working directory
 - **[checkout-and-setup](./checkout-and-setup/)** - Common repository checkout and Git configuration in one step
 - **[create-pr](./create-pr/)** - Create a new branch, commit files, and open a pull request
+- **[detect-changed-files](./detect-changed-files/)** - Check if files matching given pathspecs changed between a base ref and HEAD
 - **[merge-pr](./merge-pr/)** - Enable auto-merge on a pull request
 - **[semantic-release](./semantic-release/)** - Run semantic-release with caching and optional backmerge support
 

--- a/detect-changed-files/README.md
+++ b/detect-changed-files/README.md
@@ -1,0 +1,62 @@
+# Detect Changed Files :mag:
+
+This GitHub Action checks whether files matching the given pathspecs changed
+between a base ref and `HEAD` — for example, across a pull request. Use it to
+gate slow jobs so they only run when relevant files change.
+
+> [!IMPORTANT]  
+> This action compares against a base commit, so the repository must be checked
+> out with full history (`fetch-depth: 0`) so that the base commit is reachable.
+
+## :rocket: Usage
+
+```yaml
+name: CI
+on:
+  pull_request:
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        uses: alchemaxinc/composite-toolbox/detect-changed-files@v1.17.0
+        id: detect
+        with:
+          files: '*.go go.mod go.sum'
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Go files changed!'
+```
+
+## :gear: Inputs
+
+| Input   | Description                                                                         | Required | Default |
+| ------- | ----------------------------------------------------------------------------------- | -------- | ------- |
+| `files` | Space-separated list of git pathspecs to check; if left empty, any change counts    | :x:      | `''`    |
+| `base`  | Base ref or SHA to compare `HEAD` against; defaults to the pull request base commit | :x:      | `''`    |
+
+## :outbox_tray: Outputs
+
+| Output          | Description                                                        |
+| --------------- | ------------------------------------------------------------------ |
+| `has_changes`   | Whether any matching files changed between the base ref and `HEAD` |
+| `changed_files` | Newline-separated list of changed files matching the pathspecs     |
+
+## :warning: Prerequisites
+
+- The repository must be checked out with full history (`fetch-depth: 0`) so
+  the base commit is reachable
+- Git must be available in the runner environment
+- On events other than `pull_request`, provide the `base` input explicitly

--- a/detect-changed-files/action.yml
+++ b/detect-changed-files/action.yml
@@ -1,0 +1,80 @@
+name: 'Detect Changed Files'
+
+description: 'Check whether files matching given pathspecs changed between a base ref and HEAD, e.g. across a pull request'
+
+inputs:
+  files:
+    required: false
+    default: ''
+    description: 'Space-separated list of git pathspecs to check; if empty, any change counts'
+
+  base:
+    required: false
+    default: ''
+    description: 'Base ref or SHA to compare HEAD against; defaults to the pull request base commit'
+
+outputs:
+  has_changes:
+    description: 'Whether any matching files changed between the base ref and HEAD (true/false)'
+    value: ${{ steps.detect.outputs.has_changes }}
+
+  changed_files:
+    description: 'Newline-separated list of changed files matching the pathspecs'
+    value: ${{ steps.detect.outputs.changed_files }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Detect changed files
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        FILES="${{ inputs.files }}"
+        BASE="${{ inputs.base }}"
+
+        # Fall back to the pull request base commit when no base is supplied.
+        if [ -z "$BASE" ]; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+        fi
+
+        if [ -z "$BASE" ]; then
+          echo "::error::No 'base' input provided and this is not a pull request; pass 'base' explicitly."
+          exit 1
+        fi
+
+        # The base commit must be present locally; check out with 'fetch-depth: 0'.
+        if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+          echo "::error::Base ref '$BASE' was not found. Check out with 'fetch-depth: 0' or pass a fetched 'base'."
+          exit 1
+        fi
+
+        echo "::debug::Comparing ${BASE}...HEAD for pathspecs: ${FILES:-<all>}"
+
+        # Split the input on whitespace into an array of pathspecs and pass them quoted so
+        # Bash won't expand globs (e.g. '*.go') before git evaluates the pathspec.
+        FILES_ARR=()
+        if [ -n "$FILES" ]; then
+          read -r -a FILES_ARR <<<"$FILES"
+        fi
+
+        if [ "${#FILES_ARR[@]}" -gt 0 ]; then
+          CHANGED="$(git diff --name-only "${BASE}...HEAD" -- "${FILES_ARR[@]}")"
+        else
+          CHANGED="$(git diff --name-only "${BASE}...HEAD")"
+        fi
+
+        {
+          echo 'changed_files<<CHANGED_FILES_EOF'
+          echo "$CHANGED"
+          echo 'CHANGED_FILES_EOF'
+        } >>"$GITHUB_OUTPUT"
+
+        if [ -n "$CHANGED" ]; then
+          echo '::debug::Changes detected'
+          echo 'has_changes=true' >>"$GITHUB_OUTPUT"
+        else
+          echo '::debug::No changes detected'
+          echo 'has_changes=false' >>"$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION
Add a composite action that reports whether files matching given git pathspecs changed between a base ref and HEAD, e.g. across a pull request. It compares against the pull request base commit by default (overridable via the 'base' input) and emits 'has_changes' and 'changed_files' outputs, so callers can gate slow jobs on relevant changes without a third-party dependency.